### PR TITLE
継続日数の表示

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -52,6 +52,7 @@ class PlansController < ApplicationController
 
   # プラン達成数グラフ
   def chart 
+    #総達成数を取得
     plans = current_user.plans
     @day = Date.today
     
@@ -80,14 +81,28 @@ class PlansController < ApplicationController
     end
     gon.days = @days.reverse
 
-    # ↓現状ポイントを表示する記述になっていないと思われる
-    @points = []
+
+    #１周間の継続日数を取得
+    runs_numbers = []
+    registration_date = current_user.registration_date
+    today = Date.today
+    date_range = [*(registration_date..today)]
+
     7.times do |x|
-      today = Date.today
-      point = User.where('created_at LIKE?', "%#{today - x}%")
-      @points.push(point)
+      count = 0
+      date_range.each do |date|
+        if current_user.runs.find_by(date: date).present?
+          count += 1
+        else
+          count = 0
+        end
+      end
+      runs_numbers.push(count)
+      date_range.delete_at(-1)
     end
-    gon.point = @points.reverse
+
+    gon.runs = runs_numbers.reverse
+    
   end
 
 

--- a/app/views/plans/chart.html.erb
+++ b/app/views/plans/chart.html.erb
@@ -12,13 +12,13 @@
       labels: gon.days,
       datasets: [
         {
+          label: '継続日数',
+          data: gon.runs,
+          backgroundColor: "rgba(130,201,169,0.5)"
+        },{
           label: 'プランの総達成回数',
           data: gon.achievements_array,
           backgroundColor: "rgba(219,39,91,0.5)"
-        },{
-          label: '保持しているポイント',
-          data: gon.days,
-          backgroundColor: "rgba(130,201,169,0.5)"
         }
       ]
     },
@@ -30,11 +30,11 @@
       scales: {
         yAxes: [{
           ticks: {
-            suggestedMax: 100,
+            suggestedMax: 300,
             suggestedMin: 0,
-            stepSize: 10,
+            stepSize: 30,
             callback: function(value, index, values){
-              return  value +  '回'
+              return  value +  ''
             }
           }
         }]


### PR DESCRIPTION
# What
継続日数の表示機能
# Why
１周間の継続日数を可視化できるようにすることによって、ユーザーの持続性を高めるため。